### PR TITLE
s/process/commit/ in batch._put.

### DIFF
--- a/src/starbase/client/table/batch.py
+++ b/src/starbase/client/table/batch.py
@@ -53,7 +53,7 @@ class Batch(object):
         self._stack.append(data)
 
         if self.size and len(self._stack) > self.size:
-            self.process()
+            self.commit()
 
     def insert(self, row, columns, timestamp=None):
         return self._put(row, columns, timestamp=timestamp, encode_content=True)


### PR DESCRIPTION
Fixes the following backtrace:

  File "../python2.7/site-packages/starbase/client/table/batch.py", line 59, in insert
    return self._put(row, columns, timestamp=timestamp, encode_content=True)
  File "../python2.7/site-packages/starbase/client/table/batch.py", line 56, in _put
    self.process()
AttributeError: 'Batch' object has no attribute 'process'
