### PR TITLE
Use row-hash even when dealing single columns.

### DIFF
--- a/src/starbase/client/table/__init__.py
+++ b/src/starbase/client/table/__init__.py
@@ -344,7 +344,7 @@ class Table(object):
 
         if 1 == len(columns):
             cf = list(columns.keys())[0]
-            url = "{table_name}/{row}/{cf}".format(table_name=self.name, row=row, cf=cf)
+            url = "{table_name}/{row}/{cf}".format(table_name=self.name, row=row_hash, cf=cf)
         else:
             url = "{table_name}/{row}".format(table_name=self.name, row=row_hash)
 


### PR DESCRIPTION
When inserting into a single column, the row hash is not being
used, which causes URISyntaxExceptions server-side.
